### PR TITLE
Basic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
       language: d
       d: ldc
 script:
-- dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test
+- dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
       language: d
       d: ldc
 script:
-- dub build --compiler=ldc2 --build=release-lto-pgo --combined
+- dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
-
-# dcat
+# dcat [![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
 
 `dcat` is a very simple tool for examining performance of I/O facilities available in the D programming language ecosystem. `dcat` reads input from a file or standard input and writes results to standard output. The I/O methods to test are specified on the command line. Most tests focus on reading and writing line-by-line. Use Unix `time` or similar to get timing data.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dcat   [![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
+# dcat &nbsp; [![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
 
 `dcat` is a very simple tool for examining performance of I/O facilities available in the D programming language ecosystem. `dcat` reads input from a file or standard input and writes results to standard output. The I/O methods to test are specified on the command line. Most tests focus on reading and writing line-by-line. Use Unix `time` or similar to get timing data.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dcat [![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
+# dcat   [![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
 
 `dcat` is a very simple tool for examining performance of I/O facilities available in the D programming language ecosystem. `dcat` reads input from a file or standard input and writes results to standard output. The I/O methods to test are specified on the command line. Most tests focus on reading and writing line-by-line. Use Unix `time` or similar to get timing data.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis](https://img.shields.io/travis/jondegenhardt/dcat-perf.svg)](https://travis-ci.org/jondegenhardt/dcat-perf)
+
 # dcat
 
 `dcat` is a very simple tool for examining performance of I/O facilities available in the D programming language ecosystem. `dcat` reads input from a file or standard input and writes results to standard output. The I/O methods to test are specified on the command line. Most tests focus on reading and writing line-by-line. Use Unix `time` or similar to get timing data.

--- a/dub.json
+++ b/dub.json
@@ -43,7 +43,7 @@
         },
         "cli-test" : {
             "postBuildCommands" : [
-                "for t in byLineInBufOut byLineInRawOut; do ./bin/dcat -t $$t ./profile_data/profile_data_1.txt | cmp --quiet - ./profile_data/profile_data_1.txt; if [ $? -eq 0 ]; then echo \"Test $$t passed.\"; else echo \"Test $$t failed.\"; exit 1; fi; done"
+                "for t in `./bin/dcat --names`; do ./bin/dcat -t $$t ./profile_data/profile_data_1.txt | cmp --quiet - ./profile_data/profile_data_1.txt; if [ $? -eq 0 ]; then echo \"Test $$t passed.\"; else echo \"Test $$t failed.\"; exit 1; fi; done"
             ]
         }
     },

--- a/dub.json
+++ b/dub.json
@@ -40,6 +40,11 @@
         "pgo-profile" : {
             "buildOptions" : ["releaseMode", "optimize",  "inline", "noBoundsCheck" ],
             "dflags-ldc" : ["-d-version=LDC_PROFILE", "-fprofile-instr-generate=profile.%p.raw", "-flto=thin", "-defaultlib=phobos2-ldc-lto,druntime-ldc-lto", "-singleobj" ]
+        },
+        "cli-test" : {
+            "postBuildCommands" : [
+                "for t in byLineInBufOut byLineInRawOut; do ./bin/dcat -t $$t ./profile_data/profile_data_1.txt | cmp --quiet - ./profile_data/profile_data_1.txt; if [ $? -eq 0 ]; then echo \"Test $$t passed.\"; else echo \"Test $$t failed.\"; exit 1; fi; done"
+            ]
         }
     },
     "toolchainRequirements": {

--- a/profile_data/collect_profile_data.sh
+++ b/profile_data/collect_profile_data.sh
@@ -31,7 +31,7 @@ if [ -e app.profdata ]; then
    rm -f app.profdata
 fi
 
-for t in byLineInRawOut byLineInBufOut bufferedByLineInBufOut iopipeByLineInRawOut iopipeByLineInBufOut iopipeByLineInIOOut iopipeByLineInBufIOOut byChunkInBufOut byChunkInRawOut byChunkInByLineBufOut; do \
+for t in `$prog --names`; do \
     $prog -t $t profile_data_1.txt > /dev/null;
     cat profile_data_1.txt | $prog -t $t > /dev/null;
 done;

--- a/source/app.d
+++ b/source/app.d
@@ -80,7 +80,8 @@ struct CmdOptions
     enum defaultHeaderString = "line";
 
     string programName;
-    DCatTest dcatTest;
+    DCatTest dcatTest = DCatTest.byLineInRawOut;  // --t|test
+    bool namesWanted = false;                     // --n|names
 
     /* Returns a tuple. First value is true if command line arguments were successfully
      * processed and execution should continue, or false if an error occurred or the user
@@ -105,8 +106,8 @@ struct CmdOptions
             auto r = getopt(
                 cmdArgs,
                 std.getopt.config.caseSensitive,
-                std.getopt.config.required,
                 "t|test", testOptionDescription, &dcatTest,
+                "n|names", "Returns the list of test names.", &namesWanted,
             );
 
             if (r.helpWanted)
@@ -114,6 +115,13 @@ struct CmdOptions
                 defaultGetoptPrinter(helpText, r.options);
                 return tuple(false, 0);
             }
+            else if (namesWanted)
+            {
+                writefln("%(%s %)", dcatTestNames);
+                return tuple(false, 0);
+            }
+
+
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Add very simple basic tests. These ensure that output produced by dcat for each test is equivalent to the input. Uses test names provided by the app (`--n|names` option). The capability is also used by profile generation.

The `--t|test` command line argument is no longer required, its not required when `--n|names` is used.