### PR TITLE
Change ldc-latest-ci tests, add dmd tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ matrix:
       #if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
-    dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined
+    dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined;
   fi
 - if [[ "$LTO" == "1" ]]; then
-    dub build --compiler=ldc2 --build=release-lto --combined && dub build --build=cli-test --combined
+    dub build --compiler=ldc2 --build=release-lto --combined && dub build --build=cli-test --combined;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,28 +30,28 @@ matrix:
       language: d
       d: ldc-beta,dub-1.14.0
       env: LTO_PGO=1
-      # if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-beta,dub-1.14.0
       env: LTO_PGO=1
-      # if: type IN (cron)
+      if: type IN (cron)
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc-latest-ci,dub-1.14.0
       env: LTO=1
-      # if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-latest-ci,dub-1.14.0
       env: LTO=1
-      # if: type IN (cron)
+      if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,34 +16,49 @@ matrix:
       osx_image: xcode10.2
       group: travis_latest
       language: d
+      d: dmd
+      env: CLI_TEST=1
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      env: CLI_TEST=1
+      d: dmd
+    - os: osx
+      osx_image: xcode10.2
+      group: travis_latest
+      language: d
       d: ldc-beta
       env: LTO_PGO=1
-      #if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-beta
       env: LTO_PGO=1
-      #if: type IN (cron)
+      if: type IN (cron)
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc-latest-ci
       env: LTO=1
-      #if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-latest-ci
       env: LTO=1
-      #if: type IN (cron)
+      if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined;
   fi
 - if [[ "$LTO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto --combined && dub build --build=cli-test --combined;
+  fi
+- if [[ "$CLI_TEST" == "1" ]]; then
+    dub build --build=cli-test --combined;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,52 +4,52 @@ matrix:
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc,dub.1.14.0
+      d: ldc,dub-1.14.0
       env: LTO_PGO=1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc,dub.1.14.0
+      d: ldc,dub-1.14.0
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: dmd,dub.1.14.0
+      d: dmd,dub-1.14.0
       env: CLI_TEST=1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd,dub.1.14.0
+      d: dmd,dub-1.14.0
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc-beta,dub.1.14.0
+      d: ldc-beta,dub-1.14.0
       env: LTO_PGO=1
       # if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-beta,dub.1.14.0
+      d: ldc-beta,dub-1.14.0
       env: LTO_PGO=1
       # if: type IN (cron)
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc-latest-ci,dub.1.14.0
+      d: ldc-latest-ci,dub-1.14.0
       env: LTO=1
       # if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-latest-ci,dub.1.14.0
+      d: ldc-latest-ci,dub-1.14.0
       env: LTO=1
       # if: type IN (cron)
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,34 +5,45 @@ matrix:
       group: travis_latest
       language: d
       d: ldc
+      env: LTO_PGO=1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
+      env: LTO_PGO=1
       d: ldc
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc-beta
-      if: type IN (cron)
+      env: LTO_PGO=1
+      #if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-beta
-      if: type IN (cron)
+      env: LTO_PGO=1
+      #if: type IN (cron)
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc-latest-ci
-      if: type IN (cron)
+      env: LTO=1
+      #if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-latest-ci
-      if: type IN (cron)
+      env: LTO=1
+      #if: type IN (cron)
 script:
-- dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined
+- if [[ "$LTO_PGO" == "1" ]]; then
+    dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined
+  fi
+- if [[ "$LTO" == "1" ]]; then
+    dub build --compiler=ldc2 --build=release-lto --combined && dub build --build=cli-test --combined
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,54 +4,54 @@ matrix:
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc
+      d: ldc,dub.1.14.0
       env: LTO_PGO=1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc
+      d: ldc,dub.1.14.0
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: dmd
+      d: dmd,dub.1.14.0
       env: CLI_TEST=1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd
+      d: dmd,dub.1.14.0
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc-beta
+      d: ldc-beta,dub.1.14.0
       env: LTO_PGO=1
-      if: type IN (cron)
+      # if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-beta
+      d: ldc-beta,dub.1.14.0
       env: LTO_PGO=1
-      if: type IN (cron)
+      # if: type IN (cron)
     - os: osx
       osx_image: xcode10.2
       group: travis_latest
       language: d
-      d: ldc-latest-ci
+      d: ldc-latest-ci,dub.1.14.0
       env: LTO=1
-      if: type IN (cron)
+      # if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-latest-ci
+      d: ldc-latest-ci,dub.1.14.0
       env: LTO=1
-      if: type IN (cron)
+      # if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined;


### PR DESCRIPTION
This PR makes the following changes to the Travis test setup:
- `ldc-latest-ci` build uses LTO but not PGO: [LDC #3069](https://github.com/ldc-developers/ldc/issues/3069).
- Uses `dub-1.14.0`. This avoids a bug in `dub-1.15.0` I haven't tracked down yet. `dub-1.15.0` is shipped with the recently released dmd/ldc 2.086.
- Adds dmd to the tests.