### PR TITLE
Add baseline compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,31 @@
 matrix:
   include:
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.1
+      group: travis_latest
+      language: d
+      d: ldc-1.17.0,dub-1.14.0
+      env: LTO_PGO=1
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      env: LTO_PGO=1
+      d: ldc-1.17.0,dub-1.14.0
+    - os: osx
+      osx_image: xcode11.1
+      group: travis_latest
+      language: d
+      d: dmd-2.087.0,dub-1.14.0
+      env: CLI_TEST=1
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      env: CLI_TEST=1
+      d: dmd-2.087.0,dub-1.14.0
+    - os: osx
+      osx_image: xcode11.1
       group: travis_latest
       language: d
       d: ldc,dub-1.14.0
@@ -13,7 +37,7 @@ matrix:
       env: LTO_PGO=1
       d: ldc,dub-1.14.0
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.1
       group: travis_latest
       language: d
       d: dmd,dub-1.14.0
@@ -25,7 +49,7 @@ matrix:
       env: CLI_TEST=1
       d: dmd,dub-1.14.0
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.1
       group: travis_latest
       language: d
       d: ldc-beta,dub-1.14.0
@@ -39,7 +63,7 @@ matrix:
       env: LTO_PGO=1
       if: type IN (cron)
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.1
       group: travis_latest
       language: d
       d: ldc-latest-ci,dub-1.14.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ $ dub build --compiler=ldc2 --build=release-lto --combined
 
 The executable is written to `./bin/dcat`. Run `dcat --help` to see a list of tests available, or simply look at the [code](source/app.d#L11).
 
-**Note**: _The dub.json file works with dub-1.14.0 but not dub-1.15.0 (dmd-2.086). It can be fixed for dub-1.15.0 by changing `$?` to `$$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709)._
+**Build Notes**:
+* This project does not build with dmd-2.088.0 / ldc-1.18.0 and later. This is due to an issue in the [io package version 0.2.2](https://github.com/MartinNowak/io) library triggered by the compiler release, see [issue #27](https://github.com/MartinNowak/io/issues/27).
+* The dub.json file works with dub-1.14.0 but not dub-1.15.0 (dmd-2.086). It can be fixed for dub-1.15.0 by changing `$?` to `$$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709).
 
 Tests available are based on components from:
 * [D Standard Library](https://dlang.org/phobos/index.html)


### PR DESCRIPTION
Existing Travis CI builds use the latest DMD and LDC compiler. When DMD 2.088.0 / LDC 1.18.0 was released it exposed a compilation bug in the [io](https://github.com/MartinNowak/io) package. See [Issue #27](https://github.com/MartinNowak/io/issues/27).

This PR adds the last working compiler into the Travis CI build set and lists the issue in the README.