### PR TITLE
Switch from dmd 2.088.0 to 2.088.1 to avoid atomics regression.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd-2.089.0,dub-1.14.0
+      d: dmd-2.089.1,dub-1.14.0
     - os: linux
       dist: xenial
       group: travis_latest

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ $ dub build --compiler=ldc2 --build=release-lto --combined
 The executable is written to `./bin/dcat`. Run `dcat --help` to see a list of tests available, or simply look at the [code](source/app.d#L11).
 
 **Build Notes**:
-* This project does not build with dmd-2.088.0 / ldc-1.18.0 and later. This is due to an issue in the [io package version 0.2.2](https://github.com/MartinNowak/io) library triggered by the compiler release, see [issue #27](https://github.com/MartinNowak/io/issues/27).
 * The dub.json file works with dub-1.14.0 but not dub-1.15.0 (dmd-2.086). It can be fixed for dub-1.15.0 by changing `$?` to `$$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709).
+* This project does not build with dmd-2.088.0. This is due to an issue in the [io package version 0.2.2](https://github.com/MartinNowak/io) library triggered by regression in DMD. See [druntime PR #2853](https://github.com/dlang/druntime/pull/2853). Other compiler versions are fine.
 
 Tests available are based on components from:
 * [D Standard Library](https://dlang.org/phobos/index.html)


### PR DESCRIPTION
See
* [io PR #33](https://github.com/MartinNowak/io/pull/33)
* [druntime PR #2853](https://github.com/dlang/druntime/pull/2853)