### PR TITLE
Switch tsv-utils to version 1.5.0.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
     "license"      : "BSL-1.0",
     "dependencies" : {
         "iopipe": "~>0.1.7",
-        "tsv-utils:common": "~>1.4.1"
+        "tsv-utils:common": "~>1.5.0"
     },
     "targetName" : "dcat",
     "targetPath" : "bin",


### PR DESCRIPTION
The dub dependency specification `"tsv-utils:common": "~>1.4.1"` picks up the most recent version in the `1.4.x` sequence, but doesn't appear to automatically pull `1.5.0`.