### PR TITLE
Switch to dub-1.15.0 and later.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,12 @@ matrix:
       language: d
       env: CLI_TEST=1
       d: dmd
-#    - os: linux
-#      >>> LTO_PGO fails with ldc-1.20.0
-#      dist: xenial
-#      group: travis_latest
-#      language: d
-#      env: LTO_PGO=1
-#      d: ldc-1.20.0
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      env: LTO_PGO=1
+      d: ldc-1.20.0
     - os: linux
       dist: xenial
       group: travis_latest
@@ -47,13 +46,12 @@ matrix:
       language: d
       env: LTO=1
       d: ldc-1.20.0
-#    - os: linux
-#      >>> LTO_PGO fails with ldc-1.20.0
-#      dist: xenial
-#      group: travis_latest
-#      language: d
-#      env: LTO_PGO=1
-#      d: ldc
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      env: LTO_PGO=1
+      d: ldc
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
@@ -66,20 +64,18 @@ matrix:
       language: d
       d: dmd
       env: CLI_TEST=1
-#    - os: osx
-#      >>> LTO_PGO fails with ldc-1.20.0
-#      osx_image: xcode11.1
-#      group: travis_latest
-#      language: d
-#      d: ldc-1.20.0
-#      env: LTO_PGO=1
-#    - os: osx
-#      >>> LTO_PGO fails with ldc-1.20.0
-#      osx_image: xcode11.1
-#      group: travis_latest
-#      language: d
-#      d: ldc
-#      env: LTO_PGO=1
+    - os: osx
+      osx_image: xcode11.1
+      group: travis_latest
+      language: d
+      d: ldc-1.20.0
+      env: LTO_PGO=1
+    - os: osx
+      osx_image: xcode11.1
+      group: travis_latest
+      language: d
+      d: ldc
+      env: LTO_PGO=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
@@ -110,10 +106,10 @@ matrix:
       if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
-    dub build --compiler=ldc2 --build=release-lto-pgo --combined && dub build --build=cli-test --combined;
+    dub build --compiler=ldc2 --build=release-lto-pgo --build-mode=allAtOnce --combined && dub build --build=cli-test --combined;
   fi
 - if [[ "$LTO" == "1" ]]; then
-    dub build --compiler=ldc2 --build=release-lto --combined && dub build --build=cli-test --combined;
+    dub build --compiler=ldc2 --build=release-lto --build-mode=allAtOnce --combined && dub build --build=cli-test --combined;
   fi
 - if [[ "$CLI_TEST" == "1" ]]; then
     dub build --build=cli-test --combined;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ matrix:
   # - Linux, dmd-2.090.1
   # - Linux, dmd (latest)
   # - Linux, ldc-1.20.0, lto/pgo
-  # - Linux, ldc-1.20.0          (Default because LTO only fails)
-  # - Linux, ldc-1.20.0, lto     (LTO only because LTO/PGO fails)
+  # - Linux, ldc-1.20.0
+  # - Linux, ldc-1.20.0, lto
   # - Linux, ldc (latest), lto/pgo
   # - OS X, dmd-2.090.1
   # - OS X, dmd (latest)
@@ -89,7 +89,7 @@ matrix:
       language: d
       d: ldc-latest-ci
       env: LTO=1
-      if: type IN (cron)
+#      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
@@ -103,7 +103,7 @@ matrix:
       language: d
       d: ldc-latest-ci
       env: LTO=1
-      if: type IN (cron)
+#      if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto-pgo --build-mode=allAtOnce --combined && dub build --build=cli-test --combined;

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,28 +82,28 @@ matrix:
       language: d
       d: ldc-beta
       env: LTO_PGO=1
-#      if: type IN (cron)
+      if: type IN (cron)
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
       d: ldc-latest-ci
       env: LTO=1
-#      if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-beta
       env: LTO_PGO=1
-#      if: type IN (cron)
+      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-latest-ci
       env: LTO=1
-#      if: type IN (cron)
+      if: type IN (cron)
 script:
 - if [[ "$LTO_PGO" == "1" ]]; then
     dub build --compiler=ldc2 --build=release-lto-pgo --build-mode=allAtOnce --combined && dub build --build=cli-test --combined;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,13 @@ matrix:
       language: d
       env: CLI_TEST=1
       d: dmd
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      env: LTO_PGO=1
-      d: ldc-1.20.0
+#    - os: linux
+#      >>> LTO_PGO fails with ldc-1.20.0
+#      dist: xenial
+#      group: travis_latest
+#      language: d
+#      env: LTO_PGO=1
+#      d: ldc-1.20.0
     - os: linux
       dist: xenial
       group: travis_latest
@@ -46,12 +47,13 @@ matrix:
       language: d
       env: LTO=1
       d: ldc-1.20.0
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      env: LTO_PGO=1
-      d: ldc
+#    - os: linux
+#      >>> LTO_PGO fails with ldc-1.20.0
+#      dist: xenial
+#      group: travis_latest
+#      language: d
+#      env: LTO_PGO=1
+#      d: ldc
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
@@ -64,25 +66,27 @@ matrix:
       language: d
       d: dmd
       env: CLI_TEST=1
-    - os: osx
-      osx_image: xcode11.1
-      group: travis_latest
-      language: d
-      d: ldc-1.20.0
-      env: LTO_PGO=1
-    - os: osx
-      osx_image: xcode11.1
-      group: travis_latest
-      language: d
-      d: ldc
-      env: LTO_PGO=1
+#    - os: osx
+#      >>> LTO_PGO fails with ldc-1.20.0
+#      osx_image: xcode11.1
+#      group: travis_latest
+#      language: d
+#      d: ldc-1.20.0
+#      env: LTO_PGO=1
+#    - os: osx
+#      >>> LTO_PGO fails with ldc-1.20.0
+#      osx_image: xcode11.1
+#      group: travis_latest
+#      language: d
+#      d: ldc
+#      env: LTO_PGO=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
       d: ldc-beta
       env: LTO_PGO=1
-      if: type IN (cron)
+#      if: type IN (cron)
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
@@ -96,7 +100,7 @@ matrix:
       language: d
       d: ldc-beta
       env: LTO_PGO=1
-      if: type IN (cron)
+#      if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,105 +24,105 @@ matrix:
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd-2.087.0,dub-1.14.0
+      d: dmd-2.087.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd-2.088.1,dub-1.14.0
+      d: dmd-2.088.1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd-2.089.1,dub-1.14.0
+      d: dmd-2.089.1
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd,dub-1.14.0
+      d: dmd
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc-1.17.0,dub-1.14.0
+      d: ldc-1.17.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: ldc-1.18.0,dub-1.14.0
+      d: ldc-1.18.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO=1
-      d: ldc-1.18.0,dub-1.14.0
+      d: ldc-1.18.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc-1.18.0,dub-1.14.0
+      d: ldc-1.18.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc,dub-1.14.0
+      d: ldc
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: dmd-2.088.1,dub-1.14.0
+      d: dmd-2.088.1
       env: CLI_TEST=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: dmd,dub-1.14.0
+      d: dmd
       env: CLI_TEST=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: ldc-1.18.0,dub-1.14.0
+      d: ldc-1.18.0
       env: LTO_PGO=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: ldc,dub-1.14.0
+      d: ldc
       env: LTO_PGO=1
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: ldc-beta,dub-1.14.0
+      d: ldc-beta
       env: LTO_PGO=1
       if: type IN (cron)
     - os: osx
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: ldc-latest-ci,dub-1.14.0
+      d: ldc-latest-ci
       env: LTO=1
       if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-beta,dub-1.14.0
+      d: ldc-beta
       env: LTO_PGO=1
       if: type IN (cron)
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
-      d: ldc-latest-ci,dub-1.14.0
+      d: ldc-latest-ci
       env: LTO=1
       if: type IN (cron)
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 matrix:
   # Current tests
-  # - Linux, dmd-2.087.0    (Last version to succeed with io-0.2.2)
-  # - Linux, dmd-2.088.1    (Last version to succeed with io-0.2.3)
-  # - Linux, dmd-2.089.0    (Fails with io-0.2.3)
+  # - Linux, dmd-2.090.1
   # - Linux, dmd (latest)
-  # - Linux, ldc-1.17.0, lto/pgo
-  # - Linux, ldc-1.18.0          (Default because LTO only fails)
-  # - Linux, ldc-1.18.0, lto     (LTO only because LTO/PGO fails)
-  # - Linux, ldc-1.18.0, lto/pgo
+  # - Linux, ldc-1.20.0, lto/pgo
+  # - Linux, ldc-1.20.0          (Default because LTO only fails)
+  # - Linux, ldc-1.20.0, lto     (LTO only because LTO/PGO fails)
   # - Linux, ldc (latest), lto/pgo
-  # - OS X, dmd-2.088.1
+  # - OS X, dmd-2.090.1
   # - OS X, dmd (latest)
-  # - OS X,  ldc-1.18.0, lto/pgo
+  # - OS X,  ldc-1.20.0, lto/pgo
   # - OS X,  ldc (latest) lto/pgo
   # Additional cron tests
   # - OS X, ldc-beta lto/pgo
@@ -24,19 +21,7 @@ matrix:
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: dmd-2.087.0
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      env: CLI_TEST=1
-      d: dmd-2.088.1
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      env: CLI_TEST=1
-      d: dmd-2.089.1
+      d: dmd-2.090.1
     - os: linux
       dist: xenial
       group: travis_latest
@@ -48,25 +33,19 @@ matrix:
       group: travis_latest
       language: d
       env: LTO_PGO=1
-      d: ldc-1.17.0
+      d: ldc-1.20.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: CLI_TEST=1
-      d: ldc-1.18.0
+      d: ldc-1.20.0
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       env: LTO=1
-      d: ldc-1.18.0
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      env: LTO_PGO=1
-      d: ldc-1.18.0
+      d: ldc-1.20.0
     - os: linux
       dist: xenial
       group: travis_latest
@@ -77,7 +56,7 @@ matrix:
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: dmd-2.088.1
+      d: dmd-2.090.1
       env: CLI_TEST=1
     - os: osx
       osx_image: xcode11.1
@@ -89,7 +68,7 @@ matrix:
       osx_image: xcode11.1
       group: travis_latest
       language: d
-      d: ldc-1.18.0
+      d: ldc-1.20.0
       env: LTO_PGO=1
     - os: osx
       osx_image: xcode11.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ dub build --compiler=ldc2 --build=release-lto --combined
 The executable is written to `./bin/dcat`. Run `dcat --help` to see a list of tests available, or simply look at the [code](source/app.d#L11).
 
 **Build Notes**:
-* The dub.json file works with dub-1.14.0 but not dub-1.15.0 (dmd-2.086). It can be fixed for dub-1.15.0 by changing `$?` to `$$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709).
+* The dub.json file works with dub-1.15.0 and later but not dub-1.14.0 and earlier. To use with dub-1.14.0 changing `$$?` to `$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709).
 * This project does not build with dmd-2.088.0. This is due to an issue in the [io package version 0.2.2](https://github.com/MartinNowak/io) library triggered by regression in DMD. See [druntime PR #2853](https://github.com/dlang/druntime/pull/2853). Other compiler versions are fine.
 
 Tests available are based on components from:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The executable is written to `./bin/dcat`. Run `dcat --help` to see a list of te
 
 **Build Notes**:
 * The dub.json file works with dub-1.15.0 and later but not dub-1.14.0 and earlier. To use with dub-1.14.0 changing `$$?` to `$?` in the `dub.json` file, in the `cli-test` section. See [dub issue #1709](https://github.com/dlang/dub/issues/1709).
+* dub packaged with dmd-2.089.x and earlier has intermittent failures on travis-ci due to stack overflows. See: [druntime PR #2904](https://github.com/dlang/druntime/pull/2904). These issues are addressed in dmd-2.090.0 and ldc-1.20.0.
 * This project does not build with dmd-2.088.0. This is due to an issue in the [io package version 0.2.2](https://github.com/MartinNowak/io) library triggered by regression in DMD. See [druntime PR #2853](https://github.com/dlang/druntime/pull/2853). Other compiler versions are fine.
 
 Tests available are based on components from:

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Clone this repo and build with LDC using the command:
 ```
-$ dub build --compiler=ldc2 --build=release-lto-pgo --combined
+$ dub build --compiler=ldc2 --build=release-lto-pgo --build-mode=allAtOnce --combined
 ```
 
 The above builds with LTO and PGO. To skip PGO and use LTO only:
 ```
-$ dub build --compiler=ldc2 --build=release-lto --combined
+$ dub build --compiler=ldc2 --build=release-lto --build-mode=allAtOnce --combined
 ```
 
 The executable is written to `./bin/dcat`. Run `dcat --help` to see a list of tests available, or simply look at the [code](source/app.d#L11).

--- a/dub.json
+++ b/dub.json
@@ -34,7 +34,7 @@
             "buildOptions" : ["releaseMode", "optimize",  "inline", "noBoundsCheck" ],
             "dflags-ldc" : ["-fprofile-instr-use=profile_data/app.profdata", "-flto=thin", "-defaultlib=phobos2-ldc-lto,druntime-ldc-lto", "-singleobj" ],
             "preBuildCommands" : [
-                "arg1=\"\" && if [ \"$$DUB_COMBINED\" = \"TRUE\" ]; then arg1=\"--combined\"; fi && arg2=\"\" && if [ \"$$DUB_FORCE\" = \"TRUE\" ]; then arg2=\"--force\"; fi && $$DUB_EXE build --config=pgo-profile --build=pgo-profile $$arg1 $$arg2"
+                "arg1=\"\" && if [ \"$$DUB_COMBINED\" = \"TRUE\" ]; then arg1=\"--combined\"; fi && arg2=\"\" && if [ \"$$DUB_FORCE\" = \"TRUE\" ]; then arg2=\"--force\"; fi && $$DUB_EXE build --config=pgo-profile --build=pgo-profile --build-mode=allAtOnce $$arg1 $$arg2"
                 ]
         },
         "pgo-profile" : {

--- a/dub.json
+++ b/dub.json
@@ -43,7 +43,7 @@
         },
         "cli-test" : {
             "postBuildCommands" : [
-                "for t in `./bin/dcat --names`; do ./bin/dcat -t $$t ./profile_data/profile_data_1.txt | cmp --quiet - ./profile_data/profile_data_1.txt; if [ $? -eq 0 ]; then echo \"Test $$t passed.\"; else echo \"Test $$t failed.\"; exit 1; fi; done"
+                "for t in `./bin/dcat --names`; do ./bin/dcat -t $$t ./profile_data/profile_data_1.txt | cmp --quiet - ./profile_data/profile_data_1.txt; if [ $$? -eq 0 ]; then echo \"Test $$t passed.\"; else echo \"Test $$t failed.\"; exit 1; fi; done"
             ]
         }
     },


### PR DESCRIPTION
`dub-1.15.0` requires a slightly different `dub.json` construct. Specifically, `$?` needs to be changed to `$$?` (in the `cli-test` section in `dub.json`). See: [druntime PR #2853](https://github.com/dlang/druntime/pull/2853).

After updates the ` --build-mode=allAtOnce` is needed, at least when building PGO instrumented builds. This prevents the `-c` linker flag from getting added, avoiding having `io` and`iopipe` built as separate `.a` files. Multiple things changed, including `dub`, `ldc`, and `io`. (`io` was changed to fix the atomics issue introduced in recent dmd versions. Not clear which change caused the issue.