### PR TITLE
Explicitly pull io dependency (iopipe v0.2.0).

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,7 @@
     "copyright"    : "Copyright (c) 2019, Jon Degenhardt",
     "license"      : "BSL-1.0",
     "dependencies" : {
+        "io": ">=0.2.4",
         "iopipe": ">=0.1.7",
         "tsv-utils:common": ">=1.5.0"
     },


### PR DESCRIPTION
With the iopipe v0.2.1 release, the dependency on `io` needs to be explicitly done in the dub.json file.